### PR TITLE
Fix/calculation error

### DIFF
--- a/lib/real_rich_text.dart
+++ b/lib/real_rich_text.dart
@@ -172,6 +172,7 @@ class ImageResolver {
   ImageConfiguration _imageConfiguration;
   ui.Image image;
   ImageResolverListener _listener;
+  ImageStreamListener _imageStreamListener;
 
   ImageResolver(this.imageProvider);
 
@@ -190,11 +191,13 @@ class ImageResolver {
     final ImageStream oldImageStream = _imageStream;
     _imageStream = imageProvider.resolve(_imageConfiguration);
     assert(_imageStream != null);
-
+    if (_imageStreamListener == null) {
+      _imageStreamListener = ImageStreamListener(_handleImageChanged);
+    }
     this._listener = listener;
     if (_imageStream.key != oldImageStream?.key) {
-      oldImageStream?.removeListener(_handleImageChanged);
-      _imageStream.addListener(_handleImageChanged);
+      oldImageStream?.removeListener(_imageStreamListener);
+      _imageStream.addListener(_imageStreamListener);
     }
   }
 
@@ -205,12 +208,12 @@ class ImageResolver {
 
   void addListening() {
     if (this._listener != null) {
-      _imageStream?.addListener(_handleImageChanged);
+      _imageStream?.addListener(_imageStreamListener);
     }
   }
 
   void stopListening() {
-    _imageStream?.removeListener(_handleImageChanged);
+    _imageStream?.removeListener(_imageStreamListener);
   }
 }
 

--- a/lib/real_rich_text.dart
+++ b/lib/real_rich_text.dart
@@ -207,13 +207,15 @@ class ImageResolver {
   }
 
   void addListening() {
-    if (this._listener != null) {
+    if (this._listener != null && this._imageStreamListener != null) {
       _imageStream?.addListener(_imageStreamListener);
     }
   }
 
   void stopListening() {
-    _imageStream?.removeListener(_imageStreamListener);
+    if (this._imageStreamListener != null) {
+      _imageStream?.removeListener(_imageStreamListener);
+    }
   }
 }
 
@@ -338,6 +340,10 @@ class _RealRichRenderParagraph extends RenderParagraph {
           TextPosition(offset: textOffset),
           bounds,
         );
+
+        if (textOffset == 0) {
+          offsetForCaret = Offset(bounds.left, offsetForCaret.dy);
+        }
 
         // found this is a overflowed image. ignore it
         if (textOffset != 0 &&

--- a/lib/real_rich_text.dart
+++ b/lib/real_rich_text.dart
@@ -342,7 +342,7 @@ class _RealRichRenderParagraph extends RenderParagraph {
         );
 
         if (textOffset == 0) {
-          offsetForCaret = Offset(bounds.left, offsetForCaret.dy);
+          offsetForCaret = Offset(0, offsetForCaret.dy);
         }
 
         // found this is a overflowed image. ignore it


### PR DESCRIPTION
when ImageSpan is the first span, dx calculation error.

当 ImageSpan 作为第一个 span 时，dx 看起来计算不对，会遮挡后面的 span。

修复之前：
![Screenshot_20190614-112909](https://user-images.githubusercontent.com/19836925/59482072-cce1c780-8e99-11e9-975d-c7d9c6b73ce4.jpg)

修复之后：
![Screenshot_20190614-113056](https://user-images.githubusercontent.com/19836925/59482081-d66b2f80-8e99-11e9-99c3-8453fe342031.jpg)

可能原因：
问题出在以下这些代码：
``` dart
Offset offsetForCaret = getOffsetForCaret(       
  TextPosition(offset: textOffset),              
  bounds,                                        
);                                               
```
当 textOffset = 0 时，也就是第一个 span 是 ImageSpan，dx 应该等于 0，当调用 `getOffsetForCaret()` 后，`offsetForCaret.dx` 大于 0，所以导致第一个 ImageSpan 绘制到后面的 span 上了。
